### PR TITLE
Pipeline support did not work

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "PowerShell Interactive Session",
+            "type": "PowerShell",
+            "request": "launch",
+            "cwd": ""
+        },
+        {
+            "name": "PowerShell: Launch Current File",
+            "type": "PowerShell",
+            "request": "launch",
+            "script": "${file}",
+            "cwd": "${file}"
+        }
+    ]
+}


### PR DESCRIPTION
Great work, this function comes really handy. The only thing that did not work was piping objects into the function as the pipeline processes the objects one by one without even knowing that there is more to come. Hence, in this example, the commas were missing.

```powershell
PS C:\> ConvertTo-Expression -Object 1, 2, 3
1,
2,
3

PS C:\> 1, 2, 3 | ConvertTo-Expression
1
2
3
```

I have added the format tests to verify the pipeline support works as well.

Thanks for the great work!